### PR TITLE
Add simple OCR script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # chapter1-basic
 깃과 깃허브 첫 실급을 위한 원격 저장소
+
+## OCR 스크립트 사용법
+
+`ocr.py` 파일은 [Tesseract](https://github.com/tesseract-ocr/tesseract)와 `pytesseract`, `Pillow`를 이용해 이미지를 텍스트로 변환합니다. 의존성이 설치되어 있다면 다음과 같이 사용할 수 있습니다.
+
+```bash
+python ocr.py image.png -l eng -o output.txt
+```
+
+- `image.png` : 인식할 이미지 파일 경로
+- `-l eng` : Tesseract 언어 코드(기본값은 `kor`)
+- `-o output.txt` : 결과를 저장할 파일 경로(생략하면 표준 출력)

--- a/ocr.py
+++ b/ocr.py
@@ -1,0 +1,42 @@
+import argparse
+from PIL import Image
+import pytesseract
+
+
+def run_ocr(image_path: str, lang: str = "kor") -> str:
+    """Run OCR on the given image using Tesseract.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the image file.
+    lang : str
+        Language code for Tesseract. Default is "kor" (Korean).
+
+    Returns
+    -------
+    str
+        Extracted text.
+    """
+    image = Image.open(image_path)
+    text = pytesseract.image_to_string(image, lang=lang)
+    return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple OCR tool using Tesseract")
+    parser.add_argument("image", help="Path to image file")
+    parser.add_argument("-l", "--lang", default="kor", help="Tesseract language code (default: kor)")
+    parser.add_argument("-o", "--output", help="Output text file path")
+    args = parser.parse_args()
+
+    text = run_ocr(args.image, args.lang)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple OCR script using pytesseract
- document how to run the script in README

## Testing
- `python ocr.py -h` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_683f9682436c8325a60b811cb018bbf9